### PR TITLE
Display reserved rockets in My profile

### DIFF
--- a/src/components/NavBar/navbar.css
+++ b/src/components/NavBar/navbar.css
@@ -10,7 +10,7 @@ nav {
 }
 
 nav img {
-  width: 100px;
+  width: 50px;
 }
 
 .navlinks {

--- a/src/components/Rockets/RocketsReserved.css
+++ b/src/components/Rockets/RocketsReserved.css
@@ -1,0 +1,34 @@
+.reserved-container {
+  min-width: 40%;
+  margin: 20px;
+}
+
+.rockets-reserved {
+  list-style: none;
+  margin: 10px 0;
+  padding: 0;
+  border: 1px solid lightgray;
+  border-radius: 8px;
+}
+
+.reserved-container li {
+  margin: 0;
+  padding: 10px 40px;
+  border-bottom: 1px solid lightgray;
+}
+
+.reserved-container li:last-child {
+  border: none;
+}
+
+@media (max-width: 390px) {
+  .reserved-container {
+    width: 340px;
+    min-width: 300px;
+    margin-inline: auto;
+  }
+
+  .reserved-container li {
+    padding: 10px;
+  }
+}

--- a/src/components/Rockets/RocketsReserved.js
+++ b/src/components/Rockets/RocketsReserved.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+import './RocketsReserved.css';
+
+const RocketsReserved = ({ rockets }) => (
+  <div className="reserved-container">
+    <h2>My Rockets</h2>
+    {rockets.length === 0 && (
+      <h3> There are no rockets reserved</h3>
+    )}
+    {rockets.length > 0 && (
+      <ul className="rockets-reserved">
+        {
+          rockets.map((rocket) => (
+            <li key={rocket.id}>{rocket.name}</li>
+          ))
+        }
+      </ul>
+    )}
+  </div>
+);
+
+RocketsReserved.propTypes = {
+  rockets: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+    description: PropTypes.string,
+    image: PropTypes.string,
+    reserved: PropTypes.bool,
+  })).isRequired,
+};
+export default RocketsReserved;

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -1,5 +1,14 @@
-const Profile = () => (
-  <h2>Profile</h2>
-);
+import { useSelector } from 'react-redux';
+import RocketsReserved from '../components/Rockets/RocketsReserved';
+
+const Profile = () => {
+  const rocketsList = useSelector((state) => state.rocketsReducer.rockets);
+  return (
+    <div className="flex">
+      <RocketsReserved rockets={rocketsList.filter((rocket) => rocket.reserved)} />
+      <RocketsReserved rockets={rocketsList.filter((rocket) => rocket.reserved)} />
+    </div>
+  );
+};
 
 export default Profile;


### PR DESCRIPTION
# Display reserved rockets in My profile

For this milestone:

- Render a list of all reserved rockets (use filter()) on the "My profile" page.

Only minor styling was added.
Of the additional requirements, only this was implemented:
- Enhance the My Profile section by adding a placeholder message when the "My Missions" or "My Rockets" lists are empty (no missions joined or no rockets reserved).

None of the other requirements were added (Add Cancel reservation and Read more buttons).